### PR TITLE
Fix LED resource name to match recent nmigen-boards changes (#755ae93)

### DIFF
--- a/blink/blink.py
+++ b/blink/blink.py
@@ -7,7 +7,7 @@ class Blinker(Elaboratable):
     
     def elaborate(self, platform):
         clk12 = platform.request("clk12")
-        led = plat.request("user_ledr_n")
+        led = plat.request("user_ledr")
         
         m = Module()
         m.domains.sync = ClockDomain()


### PR DESCRIPTION
nmigen resource names for icebreaker have changed recently after following commit: https://github.com/m-labs/nmigen-boards/commit/755ae9381bfa744ce326d59d972d06ad0dce4681

Current change fixes the code allowing to build example using most recent nmigen codebase.