### PR TITLE
Fixed all broken icebreaker examples

### DIFF
--- a/icebreaker/blink/blink.py
+++ b/icebreaker/blink/blink.py
@@ -17,7 +17,7 @@ class Blinker(Elaboratable):
 
         with m.If(counter == 0):
             m.d.sync += [
-                led.eq(~led),
+                led.o.eq(~led.o),
                 counter.eq(self.maxperiod)
             ]
         with m.Else():

--- a/icebreaker/pdm_fade_gamma/gamma_pdm.py
+++ b/icebreaker/pdm_fade_gamma/gamma_pdm.py
@@ -46,8 +46,8 @@ class Top(Elaboratable):
         m.d.comb += [
             self.pdm_g.pdm_in.eq(self.cnt.pdm_level1),
             self.pdm_r.pdm_in.eq(self.cnt.pdm_level2),
-            ledg_n.eq(self.pdm_g.pdm_out),
-            ledr_n.eq(self.pdm_r.pdm_out)
+            ledg_n.o.eq(self.pdm_g.pdm_out),
+            ledr_n.o.eq(self.pdm_r.pdm_out)
         ]
 
         return m

--- a/icebreaker/rotary_encoder/rotary_encoder.py
+++ b/icebreaker/rotary_encoder/rotary_encoder.py
@@ -32,13 +32,10 @@ class Top(Elaboratable):
         encoder_pins = platform.request("rotary_encoder")
         red = platform.request("led_r", 0)
         green = platform.request("led_g", 0)
-        leds = Cat(
-            # leds in ccw order
-            platform.request("led_g", 1),
-            platform.request("led_g", 4),
-            platform.request("led_g", 2),
-            platform.request("led_g", 3),
-        )
+        led_g_1 = platform.request("led_g", 1)
+        led_g_2 = platform.request("led_g", 4)
+        led_g_3 = platform.request("led_g", 2)
+        led_g_4 = platform.request("led_g", 3)
 
         m = Module()
 
@@ -48,9 +45,9 @@ class Top(Elaboratable):
         with m.If(self.iq_to_step_dir.step):
             m.d.sync += [
                 # on = cw, off = ccw
-                red.eq(self.iq_to_step_dir.direction),
+                red.o.eq(self.iq_to_step_dir.direction),
                 # toggle led
-                green.eq(1-green),
+                green.o.eq(1-green.o),
             ]
             # shift with wrap around
             with m.If(self.iq_to_step_dir.direction == 0):
@@ -60,7 +57,10 @@ class Top(Elaboratable):
 
         m.d.comb += [
             self.iq_to_step_dir.iq.eq(Cat(encoder_pins.in_phase, encoder_pins.quadrature)),
-            leds.eq(self.state),
+            led_g_1.o.eq(self.state[0]),
+            led_g_2.o.eq(self.state[1]),
+            led_g_3.o.eq(self.state[2]),
+            led_g_4.o.eq(self.state[3])
         ]
 
         return m


### PR DESCRIPTION
Originally the blink.py example failed with error: 
```
james@james-Laptop-13th-Gen-Intel-Core:~/Desktop/icebreaker-amaranth-examples/icebreaker/blink$ python3 blink.py 
Traceback (most recent call last):
  File "/home/james/Desktop/icebreaker-amaranth-examples/icebreaker/blink/blink.py", line 30, in <module>
    plat.build(Blinker(10000000), do_program=True)
  File "/home/james/.local/lib/python3.10/site-packages/amaranth/build/plat.py", line 105, in build
    plan = self.prepare(elaboratable, name, **kwargs)
  File "/home/james/.local/lib/python3.10/site-packages/amaranth/build/plat.py", line 145, in prepare
    fragment = Fragment.get(elaboratable, self)
  File "/home/james/.local/lib/python3.10/site-packages/amaranth/hdl/ir.py", line 42, in get
    new_obj = obj.elaborate(platform)
  File "/home/james/Desktop/icebreaker-amaranth-examples/icebreaker/blink/blink.py", line 20, in elaborate
    led.eq(~led),
TypeError: bad operand type for unary ~: 'FlippedInterface'
```