### PR TITLE
Adjusted examples to Amaranth 0.4.0+

### DIFF
--- a/icebreaker/7seg_count/7seg_count.py
+++ b/icebreaker/7seg_count/7seg_count.py
@@ -44,8 +44,8 @@ class Top(Elaboratable):
         m.submodules.tens_to_segs = self.tens_to_segs
 
         m.d.comb += [
-            Cat([seg_pins.aa, seg_pins.ab, seg_pins.ac, seg_pins.ad,
-                 seg_pins.ae, seg_pins.af, seg_pins.ag]).eq(seg_pins_cat),
+            Cat([seg_pins.aa.o, seg_pins.ab.o, seg_pins.ac.o, seg_pins.ad.o,
+                 seg_pins.ae.o, seg_pins.af.o, seg_pins.ag.o]).eq(seg_pins_cat),
             ones_counter.eq(counter[21:25]),
             tens_counter.eq(counter[25:29]),
             display_state.eq(counter[2:5]),
@@ -61,13 +61,13 @@ class Top(Elaboratable):
             with m.Case("010"):
                 m.d.sync += seg_pins_cat.eq(0)
             with m.Case("011"):
-                m.d.sync += seg_pins.ca.eq(1)
+                m.d.sync += seg_pins.ca.o.eq(1)
             with m.Case("10-"):
                 m.d.sync += seg_pins_cat.eq(self.tens_to_segs.segments)
             with m.Case("110"):
                 m.d.sync += seg_pins_cat.eq(0)
             with m.Case("111"):
-                m.d.sync += seg_pins.ca.eq(0)
+                m.d.sync += seg_pins.ca.o.eq(0)
 
         return m
 

--- a/icebreaker/blink/blink.py
+++ b/icebreaker/blink/blink.py
@@ -9,7 +9,7 @@ class Blinker(Elaboratable):
         self.maxperiod = maxperiod
 
     def elaborate(self, platform):
-        led = platform.request("led_r")
+        led = platform.request("led_r").o
 
         m = Module()
 

--- a/icebreaker/rotary_encoder/rotary_encoder.py
+++ b/icebreaker/rotary_encoder/rotary_encoder.py
@@ -30,14 +30,14 @@ class Top(Elaboratable):
 
     def elaborate(self, platform):
         encoder_pins = platform.request("rotary_encoder")
-        red = platform.request("led_r", 0)
-        green = platform.request("led_g", 0)
+        red = platform.request("led_r", 0).o
+        green = platform.request("led_g", 0).o
         leds = Cat(
             # leds in ccw order
-            platform.request("led_g", 1),
-            platform.request("led_g", 4),
-            platform.request("led_g", 2),
-            platform.request("led_g", 3),
+            platform.request("led_g", 1).o,
+            platform.request("led_g", 4).o,
+            platform.request("led_g", 2).o,
+            platform.request("led_g", 3).o,
         )
 
         m = Module()
@@ -59,7 +59,7 @@ class Top(Elaboratable):
                 m.d.sync += self.state.eq(Cat(self.state[1:], self.state[:1]))
 
         m.d.comb += [
-            self.iq_to_step_dir.iq.eq(Cat(encoder_pins.in_phase, encoder_pins.quadrature)),
+            self.iq_to_step_dir.iq.eq(Cat(encoder_pins.in_phase.i, encoder_pins.quadrature.i)),
             leds.eq(self.state),
         ]
 


### PR DESCRIPTION
In Amaranth 0.4.0 the Pin instance can no longer simply be cast to a Value,
instead you have to specify the input/output direction when accessing it. 

I changed the examples in two commits to work on newer version of Amaranth (tested against 0.5.3).
The first commit updates blink and uart, which I both flashed and tested (well it blinks and loopback is working).
The second commit fixes the remaining examples. 
There I was only able to test flashing them but not if they work as I don't have the accessories.

The pdm_fade_gamma example unfortunately doesn't build for me at all so I was unable to fix that:
```
/<censored>/icebreaker-amaranth-examples/icebreaker/pdm_fade_gamma/gamma_pdm.py:112: DeprecationWarning: `amaranth.hdl.Memory` is deprecated, use `amaranth.lib.memory.Memory` instead
  self.gamma_table = Memory(width=out_width, depth=2**in_width, init=gamma_init)
ERROR: Found error in internal cell \top.cnt.$13 ($memrd_v2) at kernel/rtlil.cc:1579:
  attribute \src "/<censored>/icebreaker-amaranth-examples/icebreaker/pdm_fade_gamma/gamma_pdm.py:122"
  cell $memrd_v2 $13
    parameter \CLK_POLARITY 1
    parameter \CLK_ENABLE 1
    parameter \CE_OVER_SRST 0
    parameter \INIT_VALUE 16'xxxxxxxxxxxxxxxx
    parameter \SRST_VALUE 16'xxxxxxxxxxxxxxxx
    parameter \ARST_VALUE 16'xxxxxxxxxxxxxxxx
    parameter \COLLISION_X_MASK 0'
    parameter \TRANSPARENCY_MASK 0'
    parameter \WIDTH 16
    parameter \ABITS 8
    parameter \MEMID "\\gamma_rd_p"
    connect \CLK \clk
    connect \EN 1'1
    connect \SRST 1'0
    connect \ARST 1'0
    connect \DATA \pdm_level_gamma_n
    connect \ADDR $4 [7:0]
  end
Traceback (most recent call last):
  File "/<censored>/icebreaker-amaranth-examples/icebreaker/pdm_fade_gamma/gamma_pdm.py", line 189, in <module>
    plat.build(Top(gamma=args.g), do_program=True)
  File "/opt/homebrew/lib/python3.11/site-packages/amaranth/build/plat.py", line 103, in build
    products = plan.execute_local(build_dir)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/amaranth/build/run.py", line 118, in execute_local
    subprocess.check_call(["sh", f"{self.script}.sh"],
  File "/opt/homebrew/Cellar/python@3.11/3.11.9_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/subprocess.py", line 413, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['sh', 'build_top.sh']' returned non-zero exit status 1.
```